### PR TITLE
Fix broken [nextPage] links and remove references to missing pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@
 <!--
     * ADDING OR UPDATING A Language
     *
-    * Make sure that you are following the [contributing guideline](https://docs.getclave.io/en/how-to-contribute-to-clave) and this PR template before submitting a PR.
+    * Make sure that you are following the [contributing guideline](https://docs.getclave.com/en/how-to-contribute-to-clave) and this PR template before submitting a PR.
     *
     * If you are adding a new language or updating an existing language, start by selecting the relevant options.
     *
@@ -14,7 +14,7 @@
 
 -   [ ] I am adding a new language
 -   [ ] I am updating an existing language
--   [ ] I have read the [contribution guidelines](https://docs.getclave.io/en/how-to-contribute-to-clave) and followed the rules accordingly
+-   [ ] I have read the [contribution guidelines](https://docs.getclave.com/en/how-to-contribute-to-clave) and followed the rules accordingly
 
 ### Locale details
 

--- a/en/about.mdx
+++ b/en/about.mdx
@@ -11,7 +11,7 @@ Welcome to Clave –  an easy-to-use, non-custodial smart wallet powered by Acco
 
 Clave ensures a smooth and intuitive onboarding process. With our innovative technologies, you can easily create an account, set a username, and start managing your digital assets without dealing with complex seed phrases or private keys. Our goal is to make blockchain accessible and easy to use for everyone, including those who are new to the space.
 
-**2- Clave Has [Hardware-Level Security](en/secure-enclave-technical)**
+**2- Clave Has [Hardware-Level Security](secure-enclave-technical)**
 
 Security is at the heart of Clave. We utilize state-of-the-art encryption techniques and hardware-level security elements like Secure Enclave and biometric authentication. This ensures that your assets are protected by the highest security standards, turning your smartphone into a secure vault for your digital assets.
 

--- a/en/meet-with-clave.mdx
+++ b/en/meet-with-clave.mdx
@@ -36,7 +36,7 @@ Gone are the days of confusing strings of numbers and letters that make little s
 #### Easy Recoverability
 
 We recognize the fear that comes with the thought of losing access to one’s digital assets. With Clave’s unique recoverability features, regaining access to your assets is straightforward without compromising security. We are offering different recovery options for all users’ segments. 
-To learn more you can check [How Does Social Recovery Works](social-recovery-clave)
+To learn more you can check [How Does Social Recovery Works](recovery-technical#second-recovery-option%3A-social-recovery)
 
 #### Sponsored Transactions
 

--- a/en/passkeys-technical.mdx
+++ b/en/passkeys-technical.mdx
@@ -53,7 +53,7 @@ Once the key is securely generated, it can be used to sign messages, a fundament
 ![Passkey's Technical Explainer](./images/passkeytechnical2.png)
 
 <Accordion title="What If The User Loses The Device?">
-  A genuine concern, but there's a silver lining. With Secure Enclave, even if your device falls into the wrong hands, accessing sensitive information is next to impossible. But how do you recover your account? We’ll be diving into our recovery approach in the [Recovery Section]("recovery").
+  A genuine concern, but there's a silver lining. With Secure Enclave, even if your device falls into the wrong hands, accessing sensitive information is next to impossible. But how do you recover your account? We’ll be diving into our recovery approach in the [Recovery Section](how-to-recover-clave).
 </Accordion>
 
 

--- a/en/recovery-technical.mdx
+++ b/en/recovery-technical.mdx
@@ -39,4 +39,4 @@ This way, called Social Recovery, is all about giving users more choices to keep
 ## Third Recovery Option: Universal Recovery with ZK-Email
 Social Recovery is a powerful tool, but it comes with a limitation: the Guardian must have an on-chain address. To overcome this, Clave has introduced a new recovery method called Universal Recovery, which allows anyone to become a Clave Guardian using their email accounts.
 
-Universal Recovery leverages ZK Email to verify DKIM signatures, ensuring a secure and trustless operation. This innovative approach expands the accessibility of guardianship without compromising security. For more technical details, refer to the [next section]("zkemail-recovery-technical").
+Universal Recovery leverages ZK Email to verify DKIM signatures, ensuring a secure and trustless operation. This innovative approach expands the accessibility of guardianship without compromising security. For more technical details, refer to the [next section](zkemail-recovery-technical).

--- a/tr/meet-with-clave.mdx
+++ b/tr/meet-with-clave.mdx
@@ -36,7 +36,7 @@ Gone are the days of confusing strings of numbers and letters that make little s
 #### Easy Recoverability
 
 We recognize the fear that comes with the thought of losing access to one’s digital assets. With Clave’s unique recoverability features, regaining access to your assets is straightforward without compromising security. We are offering different recovery options for all users’ segments. 
-To learn more you can check [How Does Social Recovery Works](recovery-technical#second-recovery-option%3A-social-recovery)
+To learn more you can check [How Does Social Recovery Works](recovery-technical#i̇kinci-kurtarma-seçeneği%3A-sosyal-kurtarma)
 
 #### Sponsored Transactions
 

--- a/tr/meet-with-clave.mdx
+++ b/tr/meet-with-clave.mdx
@@ -36,7 +36,7 @@ Gone are the days of confusing strings of numbers and letters that make little s
 #### Easy Recoverability
 
 We recognize the fear that comes with the thought of losing access to one’s digital assets. With Clave’s unique recoverability features, regaining access to your assets is straightforward without compromising security. We are offering different recovery options for all users’ segments. 
-To learn more you can check [How Does Social Recovery Works](social-recovery-clave)
+To learn more you can check [How Does Social Recovery Works](recovery-technical#second-recovery-option%3A-social-recovery)
 
 #### Sponsored Transactions
 

--- a/tr/passkeys-technical.mdx
+++ b/tr/passkeys-technical.mdx
@@ -55,5 +55,5 @@ Anahtar güvenli bir şekilde oluşturulduktan sonra, mesajları imzalamak için
 ![Passkey Teknik Açıklaması](./images/passkeytechnical2.png)
 
 <Accordion title="Kullanıcı Cihazı Kaybederse Ne Olur?">
-  Gerçek bir endişe, ancak iyi bir yanı var. Secure Enclave ile, cihazınız yanlış ellere geçse bile, hassas bilgilere erişim neredeyse imkansızdır. Peki hesabınızı nasıl kurtarırsınız? Kurtarma yaklaşımımızı [Kurtarma Bölümünde]("recovery") inceleyeceğiz.
+  Gerçek bir endişe, ancak iyi bir yanı var. Secure Enclave ile, cihazınız yanlış ellere geçse bile, hassas bilgilere erişim neredeyse imkansızdır. Peki hesabınızı nasıl kurtarırsınız? Kurtarma yaklaşımımızı [Kurtarma Bölümünde](how-to-recover-clave) inceleyeceğiz.
 </Accordion>


### PR DESCRIPTION
# Updating the Clave Docs
### Summary

This PR fixes several issues with `[nextPage]` links throughout the documentation:

- Corrected malformed slugs such as `"zkemail-recovery-technical"` that were preventing navigation.
- Updated `[nextPage]` references pointing to `.mdx` files that do not exist.

### Why?

Broken navigation links cause frustration and degrade the overall experience. These fixes improve the reliability of the docs by ensuring a smooth navigation flow across all pages.



Let me know if you'd prefer to redirect removed pages elsewhere or need additional cleanup.

### Additional Fixes

- Fixed a broken link to the contribution guide which previously pointed to `getclave.io`  
  Updated to `https://docs.getclave.com/en/how-to-contribute-to-clave` for correctness.

<!--
    * ADDING OR UPDATING A Language
    *
    * Make sure that you are following the [contributing guideline](https://docs.getclave.io/en/how-to-contribute-to-clave) and this PR template before submitting a PR.
    *
    * If you are adding a new language or updating an existing language, start by selecting the relevant options.
    *
    * Please make sure that you have replaced `LANGUAGE` with the actual name in the PR and made necessary changes to the corresponding file.
-->

### Checklist

- [ ] I am adding a new language  
- [x] I am updating an existing language  
- [x] I have read the [contribution guidelines](https://docs.getclave.com/en/how-to-contribute-to-clave) and followed the rules accordingly


### Locale details

- **Language names:** `English`, `Turkish`
